### PR TITLE
Change publication target branch to master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ CLOUDFILES_CONTAINER=my_cloudfiles_container
 
 DROPBOX_DIR=~/Dropbox/Public/
 
-GITHUB_PAGES_BRANCH=gh-pages
+GITHUB_PAGES_BRANCH=master
 
 DEBUG ?= 0
 ifeq ($(DEBUG), 1)


### PR DESCRIPTION
Github will only publish organization sites from master, not gh-pages.